### PR TITLE
Add pure function component snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There you have either the option to show the already installed snippets or insta
 
 Launch VS Code Quick Open (Ctrl + P or Cmd + P), paste the following command, and press enter.
 
-ext install vscode-react-typescript
+`ext install vscode-react-typescript`
 
 Alternatively you can open the extensions panel and search for 'Typescript React code snippets'.
 
@@ -30,6 +30,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `tsrcjc→`| `class component skeleton without import and default export lines` |
 | `tsrpcc→`| `class purecomponent skeleton` |
 | `tsrpcjc→` | `class purecomponent without import and default export lines` |
+| `tsrpfc` | `pure function component` |
 | `conc→`  | `class default constructor with props and context` |
 | `cwm→`   | `componentWillMount method` |
 | `ren→`   | `render method` |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `tsrcjc→`| `class component skeleton without import and default export lines` |
 | `tsrpcc→`| `class purecomponent skeleton` |
 | `tsrpcjc→` | `class purecomponent without import and default export lines` |
-| `tsrpfc` | `pure function component` |
+| `tsrpfc` | `pure function component skeleton` |
 | `conc→`  | `class default constructor with props and context` |
 | `cwm→`   | `componentWillMount method` |
 | `ren→`   | `render method` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-react-typescript",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "description": "Code snippets for react in typescript",
   "displayName": "Typescript React code snippets",
   "publisher": "infeng",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-react-typescript",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Code snippets for react in typescript",
   "displayName": "Typescript React code snippets",
   "publisher": "infeng",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -83,6 +83,23 @@
 		],
 		"description": "Create a React PureComponent without import and export."
 	},
+	"React Pure Function Component": {
+		"prefix": "tsrpfc",
+		"body": [
+			"export interface ${1:App}Props {",
+			"}",
+			"",			
+			"export function ${1:} (props: ${1:}Props) {",
+			"    return (",
+			"      <div>",
+			"        ${2:}",
+			"      </div>",
+			"    );",
+			"}",
+			""
+		],
+		"description": "Create a React Pure Function Component."
+	},
 	"constructor": {
 		"prefix": "conc",
 		"body": [

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -92,7 +92,7 @@
 			"export function ${1:} (props: ${1:}Props) {",
 			"    return (",
 			"      <div>",
-			"        ${2:}",
+			"        ${0}",
 			"      </div>",
 			"    );",
 			"}",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -86,6 +86,8 @@
 	"React Pure Function Component": {
 		"prefix": "tsrpfc",
 		"body": [
+			"import * as React from 'react';",
+			"",
 			"export interface ${1:App}Props {",
 			"}",
 			"",			


### PR DESCRIPTION
As described here, https://facebook.github.io/react/docs/components-and-props.html, pure components can be defined with a plain Javascript function.  This PR adds a snippet for creating a pure function component.