### PR TITLE
Add missing 'as' to import

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -101,7 +101,7 @@
 	"React Stateless Functional Component": {
 		"prefix": "tsrsfc",
 		"body": [
-			"import * React from 'react';",
+			"import * as React from 'react';",
 			"",
 			"interface ${1:App}Props {$2",
 			"}",


### PR DESCRIPTION
React Stateless Functional Component was missing the 'as' in `import * as React from 'react';`