### PR TITLE
Added default export for React Stateless Functional Component

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -140,6 +140,8 @@
 			"const $1: React.SFC<$1Props> = (props) => {",
 			"  return $0;",
 			"};"
+			""
+			"export default $1;"
 		],
 		"description": "Create a React Stateless Functional Component."
 	},


### PR DESCRIPTION
Thank you for your great snippet library.

However there was no default export for React Stateless Functional Components, which I think is vital, I always had to add them by hand