### PR TITLE
Replace deprecated React.SFC with React.FunctionComponent

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -137,7 +137,7 @@
 			"interface ${1:IApp}Props {$2",
 			"}",
 			"",
-			"const $1: React.SFC<$1Props> = (props) => {",
+			"const $1: React.FunctionComponent<$1Props> = (props) => {",
 			"  return $0;",
 			"};",
 			"",


### PR DESCRIPTION
React.SFC was deprecated as of React 16.7. More details can be found in
this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/30364